### PR TITLE
Restrict imports from syntax/location.

### DIFF
--- a/private/scheme/test/test-syntax.rkt
+++ b/private/scheme/test/test-syntax.rkt
@@ -2,7 +2,7 @@
 
 (require mzlib/etc
          planet/util
-         syntax/location
+         (only-in syntax/location quote-source-file)
          "checks.ss"
          "../syntax.ss")
 


### PR DESCRIPTION
Racket 6.2.900.6 adds syntax-source-file-name and syntax-source-directory to it,
which causes conflicts with some of Dracula's internal helpers.
